### PR TITLE
Allow for forcing a new connection and disconnecting an existing one.

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -35,6 +35,12 @@ function OtsMongoWrapper( options ) {
     this.db = db;
     this.emit( "connected", this.db );
 
+    // if the client closes the connection,
+    // clean up to allow for new connections with the same options
+    this.db.on( "close", function() {
+      var key = makeInstanceKey( options );
+      delete instances[key];
+    });
   }.bind( this ) );
 
 }

--- a/lib/db.js
+++ b/lib/db.js
@@ -81,7 +81,10 @@ function makeInstanceKey( options ) {
 OtsMongoWrapper.instance = function( options ) {
   var key = makeInstanceKey( options );
 
-  if ( !instances[key] ) {
+  if ( !instances[key] || options.forceNew ) {
+    if ( instances[key] ) {
+      instances[key].db.close();
+    }
     instances[key] = new OtsMongoWrapper( options );
   }
   return instances[key];

--- a/lib/db.js
+++ b/lib/db.js
@@ -81,10 +81,7 @@ function makeInstanceKey( options ) {
 OtsMongoWrapper.instance = function( options ) {
   var key = makeInstanceKey( options );
 
-  if ( !instances[key] || options.forceNew ) {
-    if ( instances[key] ) {
-      instances[key].db.close();
-    }
+  if ( !instances[key] ) {
     instances[key] = new OtsMongoWrapper( options );
   }
   return instances[key];


### PR DESCRIPTION
Because you can't teardown a connection directly, using this option would disconnect from the db on that key's connection and return a new connection.

This is more useful for making the library more easily testable than anything else. In the instance of `nascar-api`, this allows for the firing of new `connected` events multiple times for multiple test cases.
